### PR TITLE
add dependency to build workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,15 +18,13 @@ jobs:
             pip3 install maturin
             cd src/python_wrapper
             rustup target install x86_64-apple-darwin aarch64-apple-darwin
-            maturin build --target=aarch64-apple-darwin --universal2 --bindings=pyo3
+            maturin build --target=aarch64-apple-darwin --universal2
       - store_artifacts:
-          path: /Users/distiller/project/src/python_wrapper/target/wheels
-      - run:
-          name: "Upload to Test PyPI"
-          command: |
-            pip3 install --user twine
-            export PATH=/Users/distiller/Library/Python/3.9/bin:${PATH}
-            python3 -m twine upload --skip-existing --verbose --repository testpypi -u ${TESTPYPI_USER} -p ${TESTPYPI_PASSWORD} /Users/distiller/project/src/python_wrapper/target/wheels/*
+          path: ./src/python_wrapper/target/wheels
+      - persist_to_workspace:
+          root: ./src/python_wrapper/target
+          paths:
+            - wheels/*
 
   build-linux-wheels:
     docker:
@@ -37,18 +35,16 @@ jobs:
       - run:
           name: "Install Maturin and Build Wheels"
           command: |
-            for PYBIN in /opt/python/cp3{7,8,9,10,11}*/bin; do
-              "${PYBIN}/pip" install maturin
-              "${PYBIN}/maturin" build -m src/python_wrapper/Cargo.toml -i "${PYBIN}/python"
-             # "${PYBIN}/maturin" build -m src/python_wrapper/Cargo.toml -i "${PYBIN}/python --target x86_64-pc-windows-gnu"
-            done
+            cd src/python_wrapper
+            PYBIN_DIR="/opt/python/cp37-cp37m/bin"
+            "${PYBIN_DIR}/pip" install maturin
+            "${PYBIN_DIR}/maturin" build --bindings=pyo3
       - store_artifacts:
-          path: /root/project/src/python_wrapper/target/wheels/
-      - run:
-            name: "Upload to Test PyPI"
-            command: |
-              /opt/python/cp310-cp310/bin/pip install --user twine
-              /opt/python/cp310-cp310/bin/python -m twine upload --skip-existing --verbose --repository testpypi -u ${TESTPYPI_USER} -p ${TESTPYPI_PASSWORD} /root/project/src/python_wrapper/target/wheels/*
+          path: ./src/python_wrapper/target/wheels/
+      - persist_to_workspace:
+          root: ./src/python_wrapper/target
+          paths:
+            - wheels/*
 
   build-windows-wheels:
     executor: win/default
@@ -68,8 +64,8 @@ jobs:
       - run:
           name: Fix Cargo Config
           command: |
-            echo "[net]" >>  ~/.cargo/config
-            echo "git-fetch-with-cli = true" >>  ~/.cargo/config
+            echo "[net]" >> ~/.cargo/config
+            echo "git-fetch-with-cli = true" >> ~/.cargo/config
           shell: bash.exe
       - run:
           name: Build Wheels
@@ -80,18 +76,35 @@ jobs:
             maturin build --target=x86_64-pc-windows-msvc --bindings=pyo3
           shell: bash.exe
       - store_artifacts:
-          path: .\src\python_wrapper\target\wheels
+          path: ./src/python_wrapper/target/wheels
+      - persist_to_workspace:
+          root: ./src/python_wrapper/target
+          paths:
+            - wheels/*
+
+  publish-to-testpypi:
+    docker:
+      - image: cimg/python:3.10.7
+    steps:
+      - attach_workspace:
+         at: .
       - run:
-          name: "Upload to Test PyPI"
+          name: "Upload wheels to Test PyPI"
           command: |
             pip install --user twine
-            # export PATH=${HOME}/AppData/Roaming/Python/Python37/Scripts:${PATH}
-            python -m twine upload --skip-existing --verbose --repository testpypi -u ${TESTPYPI_USER} -p ${TESTPYPI_PASSWORD} src/python_wrapper/target/wheels/*
-          shell: bash.exe
+            for wheel in wheels/*.whl; do
+              echo "Uploading $wheel...";
+              python -m twine upload --skip-existing --verbose --repository testpypi -u ${TESTPYPI_USER} -p ${TESTPYPI_PASSWORD} "${wheel}"
+            done
 
 workflows:
-  build-and-publish:
+  build-and-integration-test:
     jobs:
       - build-linux-wheels
       - build-macos-wheels
       - build-windows-wheels
+      - publish-to-testpypi:
+          requires:
+            - build-linux-wheels
+            - build-macos-wheels
+            - build-windows-wheels


### PR DESCRIPTION
TODO: 
* add integration tests.
* consider making failed PyPI uploads (due to already existing wheel version) to be considered as hard errors.